### PR TITLE
Fixed unhandled exception on missing parameters

### DIFF
--- a/lib/passport-supinfo/strategy.js
+++ b/lib/passport-supinfo/strategy.js
@@ -371,7 +371,7 @@ Strategy.prototype._parseProfileExt = function(params) {
 
   profile.role = params.PersonRole;
 
-  if (params.PersonCampus === 'N/A') {
+  if (!params.PersonCampus || params.PersonCampus === 'N/A') {
     profile.campus = 'N/A';
     profile.campusId = 'N/A';
   } else {


### PR DESCRIPTION
It seems that the SUPINFO OpenID provider no longer returns most of the profile information (except the BoosterID and the full name) which causes the module to throw an error when it attempts to split `PersonCampus`. This pull request will prevent the module from crashing the app and will instead set `profile.campus` and `profile.campusId` to `'N/A'`.
